### PR TITLE
Use scoped sourceDirectories in purescript task

### DIFF
--- a/src/main/scala/net/eamelink/sbt/purescript/SbtPureScript.scala
+++ b/src/main/scala/net/eamelink/sbt/purescript/SbtPureScript.scala
@@ -37,7 +37,7 @@ object SbtPureScript extends AutoPlugin {
     output := (resourceManaged in purescript).value / "js" / "main.js",
 
     includeFilter in purescript := "*.purs",
-    sources in purescript := (sourceDirectories.value ** ((includeFilter in purescript).value -- (excludeFilter in purescript).value)).get,
+    sources in purescript := ((sourceDirectories in purescript).value ** ((includeFilter in purescript).value -- (excludeFilter in purescript).value)).get,
 
     purescript := {
       streams.value.log.info(s"Purescript compiling on ${(sources in purescript).value.length} source(s)")


### PR DESCRIPTION
I think this is the right thing to do. It makes it easier to include other source directories only for purescript files, and shouldn't break anything or cause any incompatibilites.

I ended up just putting a simple bower run in resourceGenerators and wanting to add all the bower dependencies during purescript compilation, without picking up js files from there.  There may be a better way to do all this -- I haven't used bower before.

I am somewhat familiar with js-engine and sbt-web, though, and noticed some of your other issues related to them, so if I make more progress with purescript (just playing around for now), I may be able to help.
