### PR TITLE
Use syncIncremental to suppress unnecessary rebuilds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .psci_modules
+target/

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ scalaVersion := "2.10.4"
 
 scalacOptions += "-feature"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.0.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.0.2")
 
 publishMavenStyle := false
 

--- a/src/main/scala/net/eamelink/sbt/purescript/SbtPureScript.scala
+++ b/src/main/scala/net/eamelink/sbt/purescript/SbtPureScript.scala
@@ -37,7 +37,7 @@ object SbtPureScript extends AutoPlugin {
     output := (resourceManaged in purescript).value / "js" / "main.js",
 
     includeFilter in purescript := "*.purs",
-    sources in purescript := (sourceDirectories.value ** ((includeFilter in purescript).value -- (excludeFilter in purescript).value)).get,
+    sources in purescript := ((sourceDirectories in purescript).value ** ((includeFilter in purescript).value -- (excludeFilter in purescript).value)).get,
 
     purescript := {
       streams.value.log.info(s"Purescript compiling on ${(sources in purescript).value.length} source(s)")


### PR DESCRIPTION
This switches the primary task to use syncIncremental, with minimal change otherwise.  Since there is always only one output and one operation, the invocation is fairly simple.  This makes subsequent rebuilds much faster.
