### PR TITLE
fix duplicate mappings error when running test command

### DIFF
--- a/src/main/scala/net/eamelink/sbt/purescript/SbtPureScript.scala
+++ b/src/main/scala/net/eamelink/sbt/purescript/SbtPureScript.scala
@@ -35,7 +35,7 @@ object SbtPureScript extends AutoPlugin {
   val basePureScriptSettings = Seq(
     executable := "psc",
     pscOptions := Nil,
-    output := (resourceManaged in purescript).value / "js" / "main.js",
+    output := (crossTarget in purescript).value / "js" / "main.js",
 
     includeFilter in purescript := "*.purs",
     sources in purescript := ((sourceDirectories in purescript).value ** ((includeFilter in purescript).value -- (excludeFilter in purescript).value)).get,


### PR DESCRIPTION
Indicating "resourceManaged" as output in purescript base setting
causes an error about "duplicate mappings" when running "test" in sbt.

The solution consist on using "crossTarget" instead of "resourceManaged".

Steps to reproduce it:
- clone this repo
- cd into play-example
- run sbt test

A similar situation has been depicted here:
https://github.com/softprops/coffeescripted-sbt/issues/6

closes #14
